### PR TITLE
[ lecturelist ] Fix: Page Layout Padding & Height Adjustment→ lecturelist#4design

### DIFF
--- a/sws/src/main/components/LectureSearchFilterPageHeader.jsx
+++ b/sws/src/main/components/LectureSearchFilterPageHeader.jsx
@@ -10,10 +10,10 @@ const FilterHeaderContainer = styled.div`
   flex-shrink: 0;
   box-sizing: border-box;
   display: flex;
-  align-items: center; /* 세로 중앙 정렬 (내용물이) */
-  justify-content: center; /* 타이틀을 수평 중앙 정렬 */
-  padding: 0rem 1.5rem; /* 좌우 패딩을 여기에 직접 줌 */
-  position: relative; /* BackButton absolute 기준 */
+  align-items: center;
+  justify-content: center; 
+  padding: 0rem 1rem;
+  position: relative;
 `;
 const HeaderContentWrapper = styled.div`
   width: 100%;

--- a/sws/src/main/page/AlarmPage.jsx
+++ b/sws/src/main/page/AlarmPage.jsx
@@ -9,15 +9,14 @@ import IconExchangeURL from '../../common/assets/icons/icon_exchange.svg';
 import IconCoffeeChatURL from '../../common/assets/icons/icon_coffeechat.svg';
 //  styled-components 정의
 const AlarmPageContainer = styled.div`
- width: calc(100% + 2rem); 
+  width: 100%; 
   height: 100%; 
-  margin-left: -1rem; 
-  margin-right: -1rem; 
   display: flex;
   flex-direction: column;
   gap:0.5rem; 
   overflow-y: auto; 
   -webkit-overflow-scrolling: touch;
+  padding:1rem 0 0 0;
 `;
 
 const AlarmItemWrapper = styled.div`
@@ -29,6 +28,7 @@ const AlarmItemWrapper = styled.div`
   flex-direction: column;
   gap: 0.5rem; 
   cursor: pointer;
+  padding:1rem;
 `;
 
 const AlarmCategoryIcon = styled.div`

--- a/sws/src/main/page/GlobalSearchPage.jsx
+++ b/sws/src/main/page/GlobalSearchPage.jsx
@@ -14,6 +14,7 @@ const GlobalSearchContainer = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   gap: 2rem;
+  padding:1rem;
 `;
 // 상단 검색 바 섹션
 const SearchBarSection = styled.div`

--- a/sws/src/main/page/Main.jsx
+++ b/sws/src/main/page/Main.jsx
@@ -38,6 +38,21 @@ import LectureImageExample from '../../common/assets/images/weave_img_ex1.svg';
     { id: 2, name: "박이화", major: "수학과", talent: "데이터 분석", interest: "머신러닝" },
     { id: 3, name: "최이화", major: "경제학과", talent: "전략 수립", interest: "투자" },
   ];
+  const MainPageContainer = styled.div`
+  width: 100%;
+  height: 100%; 
+  padding:  1rem;
+  box-sizing: border-box; 
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto; 
+  &::-webkit-scrollbar {
+    display: none; 
+  }
+  -ms-overflow-style: none;  
+  scrollbar-width: none;  
+  gap: 1.25rem;
+`;
 // MyInfoFrame 관련
 const MyInfoFrame = styled.div`
   width: 22.375rem;
@@ -630,7 +645,7 @@ export default function Main() {
     navigate('/lectures/my'); 
   };
   return (
-    <> 
+    <MainPageContainer>
       <MyInfoFrame> 
         <MyInfoInnerContent>
           <ProfileSection> 
@@ -700,6 +715,6 @@ export default function Main() {
           ))}
         </MainListEwhainContainer>
       </EwhainFrame>
-    </>
+    </MainPageContainer>
   );
 }

--- a/sws/src/main/page/lecture/LectureDateFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureDateFilterPage.jsx
@@ -17,9 +17,8 @@ const PageContainer = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   padding-bottom: 8.5rem;
-  margin-top: -1rem;
   gap:0rem;
-  min-height: 100vh;
+  padding:1rem 0  8.5rem 0;
 `;
 const HeaderWrapper = styled.div`
   width: 100%;

--- a/sws/src/main/page/lecture/LectureDetailPage.jsx
+++ b/sws/src/main/page/lecture/LectureDetailPage.jsx
@@ -18,18 +18,15 @@ import LectureDetailImage3 from '../../../common/assets/images/weave_img_ex3.svg
 // styled-components 정의
 const DetailPageContainer = styled.div`
   width: 100%;
-  height: auto; 
+  height: 100%;
   min-height: 100%; 
   position: relative; 
   -webkit-overflow-scrolling: touch;
   &::-webkit-scrollbar { display: none; }
   -ms-overflow-style: none;
   scrollbar-width: none;
-  margin-left: -1rem; 
-  margin-right: -1rem; 
-  margin-top:-1rem;
-  padding-bottom: 8.5rem; 
   box-sizing: border-box;
+  padding:1rem 0  8.5rem 0;
 `;
 //상단버튼컨테이너
 const TopButtonsContainer = styled.div`
@@ -154,7 +151,7 @@ const LectureDetailFrame = styled.div`
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  padding: 1.375rem 1.5rem 1.5rem; 
+  padding: 1.375rem 1.5rem  8.5rem 1.5rem; 
   gap: 1rem; 
   margin-bottom: 8.5rem; 
    z-index: 2;

--- a/sws/src/main/page/lecture/LectureFormatFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureFormatFilterPage.jsx
@@ -13,7 +13,6 @@ const PageContainer = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   padding-bottom: 8.5rem;
-  margin-top: -1rem;
   gap:0rem;
   min-height: 100vh;
 `;

--- a/sws/src/main/page/lecture/LectureList.jsx
+++ b/sws/src/main/page/lecture/LectureList.jsx
@@ -16,10 +16,11 @@ import IconBackURL from '../../../common/assets/icons/icon_back.svg';
 import LectureImageExample from '../../../common/assets/images/weave_img_ex1.svg';
 const LectureListContainer = styled.div`
   width: 100%;
-  height: auto;
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: 1.25rem; 
+  padding:1rem;
 `;
 
 const SearchFilterSection = styled.div`

--- a/sws/src/main/page/lecture/LectureLocationFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureLocationFilterPage.jsx
@@ -14,7 +14,6 @@ const PageContainer = styled.div`
   flex-direction: column;
   box-sizing: border-box;
   padding-bottom: 8.5rem;
-  margin-top: -1rem;
   gap:0rem;
   min-height: 100vh;
 `;

--- a/sws/src/main/page/lecture/LectureMy.jsx
+++ b/sws/src/main/page/lecture/LectureMy.jsx
@@ -13,11 +13,12 @@ import IconBackURL from '../../../common/assets/icons/icon_back.svg';
 //강의 이미지 예시 (임시)
 import LectureImageExample from '../../../common/assets/images/weave_img_ex1.svg';
 const MyLecturePageContainer = styled.div` /* RecommendPageContainer와 동일 */
-   width: 100%;
-  height: auto;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: 1.25rem; 
+  padding:1rem;
 `;
 
 // 필터 바 아이콘 관련 styled-components

--- a/sws/src/main/page/lecture/LectureRecommend.jsx
+++ b/sws/src/main/page/lecture/LectureRecommend.jsx
@@ -14,10 +14,11 @@ import IconBackURL from '../../../common/assets/icons/icon_back.svg';
 import LectureImageExample from '../../../common/assets/images/weave_img_ex1.svg';
 const RecommendPageContainer = styled.div`
   width: 100%;
-  height: auto;
+  height: 100%;
   display: flex;
   flex-direction: column;
   gap: 1.25rem; 
+  padding:1rem;
 `;
 
 // 필터 바 아이콘 관련 styled-components 

--- a/sws/src/main/page/lecture/LectureRecommendFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureRecommendFilterPage.jsx
@@ -17,9 +17,7 @@ const FilterPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding: 0 1.5rem; 
-  gap: 1rem; 
-  padding-bottom: 8.5rem;
+  padding: 0 2rem; 
 `;
 // [필터 컴포넌트 프레임] 
 const FilterItemContainer = styled.div`

--- a/sws/src/main/page/lecture/LectureSearchFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureSearchFilterPage.jsx
@@ -9,11 +9,11 @@ import SortGridIconURL from '../../../common/assets/icons/sort_list.svg';
 import SortListIconURL from '../../../common/assets/icons/sort_gallery.svg';
 const FilterPageContainer = styled.div`
   width: 100%;
-  height: auto; 
+  height: 100%; 
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding: 0 1.5rem; 
+  padding: 0 2rem; 
 `;
 // [필터 컴포넌트 프레임] 
 const FilterItemContainer = styled.div`

--- a/sws/src/main/page/lecture/LectureSortFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureSortFilterPage.jsx
@@ -12,11 +12,9 @@ const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding-bottom: 8.5rem;
-  margin-top: -1rem;
   gap:0rem;
-  min-height: 100vh;
-`;
+  padding:1rem 0  8.5rem 0
+  ;`;
 const HeaderWrapper = styled.div`
   width: 100%;
   height: 3.5rem; 

--- a/sws/src/main/page/lecture/LectureStatusFilterPage.jsx
+++ b/sws/src/main/page/lecture/LectureStatusFilterPage.jsx
@@ -12,10 +12,9 @@ const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding-bottom: 8.5rem;
-  margin-top: -1rem;
+  padding:1rem 0  8.5rem 0;
   gap:0rem;
-  min-height: 100vh;
+ 
 `;
 const HeaderWrapper = styled.div`
   width: 100%;

--- a/sws/src/main/page/lecture/MyLectureFilterPage.jsx
+++ b/sws/src/main/page/lecture/MyLectureFilterPage.jsx
@@ -14,9 +14,7 @@ const FilterPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  padding: 0 1.5rem; 
-  gap: 1rem; 
-  padding-bottom: 8.5rem;
+  padding: 0 2rem; 
 `;
 const FilterItemContainer = styled.div`
   width: 100%;


### PR DESCRIPTION
## 📌 Related Issue

close#4

<br/>

## 🚀 Description

 페이지의 레이아웃  패딩과 높이(`height`) 관련 스타일을 조정했습니다.

**패딩 적용**: `Layout` 컴포넌트에서 전역 패딩이 제거됨에 따라, 강의 관련 주요 페이지들의 최상위 컨테이너에 적절한 패딩을 개별적으로 적용했습니다.
-   **높이(`height`) 조정**: 각 페이지의 최상위 컨테이너 `height`를 `100%` (또는 `min-height: 100%`)로 설정하여, `Layout` 컴포넌트의 높이(`55.035rem`)에 맞춰 유동적으로 조절되도록 했습니다. 

<br/>

## 📸 Screenshot

<!-- (UI 변경 시) 스크린샷 또는 GIF 첨부 -->

<br/>

## 📢 Notes

 **변경된 파일**: `src/main/page/` 및 `src/main/page/lecture/` 폴더 내의 여러 페이지 컴포넌트 파일들 (예: `Main.jsx`, `AlarmPage.jsx`, `GlobalSearchPage.jsx`, `LectureList.jsx`, `LectureDetailPage.jsx`, `LectureDateFilterPage.jsx` 등)이 수정되었습니다.
