### PR TITLE
feat: 강의 상세 페이지 API 연동 및 UI 데이터 바인딩

### DIFF
--- a/sws/src/api/course.js
+++ b/sws/src/api/course.js
@@ -1,0 +1,22 @@
+import { client } from './client';
+
+export const getLectureDetail = async (courseId) => { 
+    try {
+        const response = await client.get(`/course/${courseId}`);
+        console.log(`강의 상세 조회 성공 (ID: ${courseId}):`, response.data);
+        return response.data; 
+    } catch (error) {
+        console.error(`강의 상세 조회 실패 (ID: ${courseId}):`, error);
+        throw error; 
+    }
+};
+export const getLectureList = async (params = {}) => {
+    try {
+        const response = await client.get(`/course`, { params }); 
+        console.log("강의 목록 조회 성공:", response.data);
+        return response.data;
+    } catch (error) {
+        console.error("강의 목록 조회 실패:", error);
+        throw error;
+    }
+};

--- a/sws/src/main/page/Main.jsx
+++ b/sws/src/main/page/Main.jsx
@@ -644,6 +644,7 @@ export default function Main() {
   const handleProLecCountClick = () => {
     navigate('/lectures/my'); 
   };
+ 
   return (
     <MainPageContainer>
       <MyInfoFrame> 

--- a/sws/src/main/page/lecture/LectureDetailPage.jsx
+++ b/sws/src/main/page/lecture/LectureDetailPage.jsx
@@ -1,20 +1,18 @@
 // src/main/pages/LectureDetailPage.jsx
-import React , { useState }from 'react';
+import React , { useEffect,useState }from 'react';
 import styled from 'styled-components';
 import { useParams, useNavigate  } from 'react-router-dom';
 import { Swiper, SwiperSlide } from 'swiper/react'; 
 import { Pagination, Navigation } from 'swiper/modules'; 
+import { getLectureDetail } from '../../../api/course';
 import 'swiper/css'; 
 import 'swiper/css/pagination'; 
-// 필요한 아이콘 URL 임포트 
+// 필요한 아이콘 URL  
 import IconBookmarkActive from '../../../common/assets/icons/icon_bookmark.svg'; 
 import IconBookmarkDis from '../../../common/assets/icons/icon_bookmark_dis.svg';
 import IconBackURL from '../../../common/assets/icons/icon_back.svg'; 
 import IconExportURL from '../../../common/assets/icons/icon_export.svg';
-import ProfilePlaceholder from '../../../common/assets/images/profile_ex1.jpg'; 
-import LectureDetailImage1 from '../../../common/assets/images/weave_img_ex1.svg';
-import LectureDetailImage2 from '../../../common/assets/images/weave_img_ex2.svg';
-import LectureDetailImage3 from '../../../common/assets/images/weave_img_ex3.svg';
+import ProfileExampleImage from '../../../common/assets/images/profile_ex1.jpg';
 // styled-components 정의
 const DetailPageContainer = styled.div`
   width: 100%;
@@ -393,113 +391,58 @@ const ApplyButton = styled(PopupButton)`
   color: #FFFFFF;
 `;
 
-// 강의 상세 데이터 예시 (임시) - 모든 상세 정보 포함
-const dummyLectureDetails = {
-  1: {
-    id: 1,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder, // 로컬 이미지 경로 사용
-    instructorNickname: "김코딩",
-    instructorDepartment: "컴퓨터공학과 22학번",
-    title: "React 완전 정복: 실전 프로젝트로 배우는 웹 개발",
-    category: "개발/프로그래밍",
-    period: "2024.08.01 ~ 2024.08.31",
-    region: "이화여자대학교 주변",
-    description: "본 강의는 ReactJS의 핵심 개념부터 실제 프로젝트 개발에 필요한 고급 기술까지 총망라하여 다룹니다. JSX, Props, State, Hooks의 깊은 이해를 바탕으로 Todo List, 쇼핑몰 UI, 간단한 블로그 등을 직접 구현하며 실전 감각을 익힙니다. 클린 코드 작성법, 컴포넌트 최적화 기법도 함께 배울 수 있습니다.\n\n강의 대상:\n- React를 처음 접하는 개발자\n- React 기본 문법은 알지만 실전 프로젝트에 어려움을 겪는 분\n- 최신 React 트렌드와 효율적인 개발 방법을 배우고 싶은 분",
-  },
-  2: {
-    id: 2,
-    images: [LectureDetailImage2, LectureDetailImage1, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "이디자인",
-    instructorDepartment: "디자인학과 21학번",
-    title: "UI/UX 디자인 실전: 사용자 경험을 이해하고 구현하기",
-    category: "디자인",
-    period: "2024.08.15 ~ 2024.09.15",
-    region: "온라인",
-    description: "사용자 중심 디자인의 중요성을 이해하고, Figma를 활용하여 와이어프레임부터 고해상도 프로토타입까지 디자인하는 과정을 배웁니다. 사용성 테스트, 피드백 반영 등 실제 UI/UX 디자이너의 업무 프로세스를 경험하며, 포트폴리오에 활용 가능한 결과물을 만듭니다.\n\n강의 대상:\n- UI/UX 디자인에 관심 있는 모든 분\n- Figma 툴 사용법을 익히고 싶은 분\n- 디자인 사고를 배우고 싶은 분",
-  },
-  3: {
-    id: 3,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "박데이터",
-    instructorDepartment: "수학과 20학번",
-    title: "SQL 고급 활용: 데이터베이스 최적화와 분석",
-    category: "데이터베이스",
-    period: "2024.09.01 ~ 2024.09.30",
-    region: "대면 (스터디룸)",
-    description: "SQL 쿼리 작성 능력 향상과 데이터베이스 성능 최적화 기법을 깊이 있게 다룹니다. 서브쿼리, 조인, 인덱스 최적화, 트랜잭션 관리 등 실무에서 필요한 고급 SQL 스킬을 학습합니다. 데이터 분석가를 위한 SQL 활용법도 포함됩니다.\n\n강의 대상:\n- SQL 기본 문법을 아는 분\n- 데이터 분석 및 관리에 SQL을 활용하고자 하는 분\n- 데이터베이스 성능 튜닝에 관심 있는 분",
-  },
-  4: {
-    id: 4,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "최파이",
-    instructorDepartment: "컴퓨터공학과 23학번",
-    title: "Python 데이터 분석: 판다스와 넘파이 마스터",
-    category: "데이터 과학",
-    period: "2024.09.10 ~ 2024.10.10",
-    region: "온라인",
-    description: "파이썬을 이용한 데이터 분석의 기본기를 다지고, Pandas와 NumPy 라이브러리를 활용하여 데이터 전처리, 가공, 분석 및 시각화까지 전 과정을 실습합니다. 실제 데이터를 활용한 미니 프로젝트를 통해 분석 역량을 강화합니다.",
-  },
-  5: {
-    id: 5,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "정자바",
-    instructorDepartment: "컴퓨터공학과 20학번",
-    title: "Java 백엔드 개발: Spring Boot와 REST API",
-    category: "백엔드 개발",
-    period: "2024.09.25 ~ 2024.10.25",
-    region: "온라인/대면",
-    description: "Java와 Spring Boot를 이용하여 효율적이고 확장 가능한 RESTful API를 구축하는 방법을 배웁니다. 데이터베이스 연동, 인증/인가, 예외 처리 등 백엔드 개발에 필요한 핵심 기술들을 실습 위주로 다룹니다.",
-  },
-  6: {
-    id: 6,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "김코딩",
-    instructorDepartment: "컴퓨터공학과 22학번",
-    title: "React 기초: 프론트엔드 첫걸음",
-    category: "프론트엔드 개발",
-    period: "2024.08.01 ~ 2024.08.31",
-    region: "이화여자대학교 주변",
-    description: "React에 처음 입문하는 분들을 위한 기초 강의입니다. React의 기본 개념, JSX 문법, 컴포넌트 구조, props와 state 관리 등 프론트엔드 개발에 필요한 기본적인 React 사용법을 쉽고 재미있게 학습합니다.",
-  },
-  7: {
-    id: 7,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "이디자인",
-    instructorDepartment: "디자인학과 21학번",
-    title: "UX 리서치: 사용자 요구사항을 찾아내기",
-    category: "UI/UX 디자인",
-    period: "2024.08.15 ~ 2024.09.15",
-    region: "온라인",
-    description: "사용자 중심 디자인의 첫 단계인 UX 리서치 방법에 대해 배웁니다. 사용자 인터뷰, 설문조사, 페르소나 만들기 등 다양한 리서치 방법론을 실습하고, 이를 통해 사용자의 진짜 요구사항을 도출하는 역량을 키웁니다.",
-  },
-  8: {
-    id: 8,
-    images: [LectureDetailImage1, LectureDetailImage2, LectureDetailImage3],
-    instructorProfile: ProfilePlaceholder,
-    instructorNickname: "박데이터",
-    instructorDepartment: "수학과 20학번",
-    title: "데이터 모델링: 관계형 데이터베이스 설계",
-    category: "데이터베이스",
-    period: "2024.09.01 ~ 2024.09.30",
-    region: "대면 (스터디룸)",
-    description: "데이터베이스 설계의 핵심인 데이터 모델링에 대해 심도 있게 다룹니다. ERD(개체-관계 다이어그램) 작성, 정규화, 관계 설정 등 관계형 데이터베이스를 효율적으로 설계하는 방법론을 학습하고 실습합니다.",
-  },
-};
 // LectureDetailPage 함수 컴포넌트 정의
 export default function LectureDetailPage() {
   const { lectureId } = useParams();
   const navigate = useNavigate();
+  const [lectureDetail, setLectureDetail] = useState(null); 
+  const [loading, setLoading] = useState(true); 
+  const [error, setError] = useState(null);
   const [showApplyPopup, setShowApplyPopup] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
-  const lecture = dummyLectureDetails[parseInt(lectureId)]; 
-  if (!lecture) {
+    // API 호출 로직 
+  useEffect(() => {
+    const fetchLecture = async () => {
+      try {
+        setLoading(true); 
+        setError(null); 
+        const responseData = await getLectureDetail(lectureId);
+        if (responseData.isSuccess && responseData.payload) {
+            setLectureDetail(responseData.payload); 
+            setIsBookmarked(responseData.payload.bookmarked); 
+        } else {
+            setError(new Error(responseData.message || "강의 정보를 불러오지 못했습니다."));
+        }
+      } catch (err) {
+        console.error("강의 상세 정보 로드 중 오류 발생:", err);
+        setError(err); 
+      } finally {
+        setLoading(false); 
+      }
+    };
+
+    if (lectureId) { 
+      fetchLecture();
+    }
+  }, [lectureId]); 
+  if (loading) {
+    return (
+      <DetailPageContainer>
+        <div>강의 상세 정보를 불러오는 중입니다...</div>
+      </DetailPageContainer>
+    );
+  }
+  if (error) {
+    return (
+      <DetailPageContainer>
+        <div>오류가 발생했습니다: {error.message}</div>
+        <ChatButton onClick={() => navigate(-1)}> 이전 페이지로 돌아가기</ChatButton>
+      </DetailPageContainer>
+    );
+  }
+  // API 호출은 성공했지만 데이터가 없는 경우
+  // 백엔드에서 404가 아닌 200 OK에 null 데이터를 주는 경우 등
+  if (!lectureDetail) {
     return (
       <DetailPageContainer>
         <p>죄송합니다. 요청하신 강의 정보를 찾을 수 없습니다.</p>
@@ -551,19 +494,19 @@ export default function LectureDetailPage() {
       {/* 강의 이미지 */}
       <LectureImageFrame>
         <Swiper
-          modules={[Pagination, Navigation]} 
-          spaceBetween={0} 
-          pagination={{ 
-            clickable: true, 
+          modules={[Pagination, Navigation]}
+          spaceBetween={0}
+          pagination={{
+            clickable: true,
             el: '.swiper-pagination',
-          }} 
+          }}
           loop={true} 
-          grabCursor={true} 
-          style={{ width: '100%', height: '100%' }} 
+          grabCursor={true}
+          style={{ width: '100%', height: '100%' }}
         >
-          {lecture.images.map((imgSrc, index) => (
+          {lectureDetail.images && lectureDetail.images.map((imgSrc, index) => (
             <SwiperSlide key={index}>
-              <LectureActualImage src={imgSrc} alt={`${lecture.title} 이미지 ${index + 1}`} />
+              <LectureActualImage src={imgSrc} alt={`${lectureDetail.courseTitle} 이미지 ${index + 1}`} />
             </SwiperSlide>
           ))}
             <div className="swiper-pagination"></div>
@@ -573,35 +516,36 @@ export default function LectureDetailPage() {
       <LectureDetailFrame>
         {/* 강의자 프로필 프레임 */}
         <InstructorProfileFrame>
-          <InstructorProfileImage src={lecture.instructorProfile} alt={lecture.instructorNickname} />
+            <InstructorProfileImage
+            src={ProfileExampleImage} 
+            alt={lectureDetail.teacher?.nickname}
+          />
           <InstructorInfoTextContainer>
-            <InstructorNickname>{lecture.instructorNickname}</InstructorNickname>
-            <InstructorDepartment>{lecture.instructorDepartment}</InstructorDepartment>
+            <InstructorNickname>{lectureDetail.teacher?.nickname}</InstructorNickname>
+            <InstructorDepartment>{lectureDetail.teacher?.department}</InstructorDepartment> {/* college와 department 중 선택 */}
           </InstructorInfoTextContainer>
         </InstructorProfileFrame>
-
         {/* 강의 타이틀 */}
-        <LectureTitleText>{lecture.title}</LectureTitleText>
-
+        <LectureTitleText>{lectureDetail.courseTitle}</LectureTitleText>
         {/* 강의 상세 카테고리 프레임 */}
         <LectureCategoryFrame>
           <LectureCategoryItem>
             <CategoryLabel>카테고리</CategoryLabel>
-            <CategoryValue>{lecture.category}</CategoryValue>
+            <CategoryValue>{lectureDetail.courseCategory}</CategoryValue>
           </LectureCategoryItem>
           <LectureCategoryItem>
             <CategoryLabel>기간</CategoryLabel>
-            <CategoryValue>{lecture.period}</CategoryValue>
+            <CategoryValue>{`${lectureDetail.period.start} ~ ${lectureDetail.period.end}`}</CategoryValue>
           </LectureCategoryItem>
           <LectureCategoryItem>
             <CategoryLabel>지역</CategoryLabel>
-            <CategoryValue>{lecture.region}</CategoryValue>
+            <CategoryValue>{lectureDetail.courseCity}</CategoryValue>
           </LectureCategoryItem>
         </LectureCategoryFrame>
         {/* 디바이더 */}
         <Divider />
         {/* 강의상세정보-줄글 */}
-        <LectureFullDescription>{lecture.description}</LectureFullDescription>
+        <LectureFullDescription>{lectureDetail.description}</LectureFullDescription>
       </LectureDetailFrame>
 
       <FooterBar>


### PR DESCRIPTION
## 📌 Related Issue

close#35

<br/>

## 🚀 Description

강의 상세 페이지의 더미 데이터를 실제 API 데이터로 연결

-   **강의 상세 페이지 (`/lectures/detail/:id`)**:
    -   강의 ID를 기반으로 강의 상세 조회 API(`GET /course/{courseId}`)를 호출하여 데이터를 가져오도록 연동.
    -   API 응답(`payload`)의 `courseTitle`, `images`, `description` 등 상세 정보를 UI에 바인딩
-   **강의 목록 조회 (`GET /course`)**: 테스트를 위해 강의 목록 조회 API를 `src/api/course.js`에 추가했습니다. (임시로 `Main.jsx`에서 호출하여 유효한 강의 ID를 확인.)

<br/>

## 📸 Screenshot

<img width="291" height="677" alt="image" src="https://github.com/user-attachments/assets/9bb72428-8fb4-46f2-9f2f-8659353729e0" />
<br/>

## 📢 Notes

**적용 브랜치**: `lecturelist#35api` -> `develop`
