### PR TITLE
feat: [FE/Main] 메인페이지 수정

### DIFF
--- a/sws/src/common/components/Header.jsx
+++ b/sws/src/common/components/Header.jsx
@@ -98,19 +98,19 @@ if (React.isValidElement(header)) {
         );
     } else { 
         return (
-            <HeaderWrapper>
+            <HeaderWrapperBig>
                 <BACK_ARROW
                     style={{
                         color: theme.colors.black,
                         position: 'absolute',
-                        top: '50%',
-                        left: '1.7rem',
+                        //top: '50%',
+                        //left: '1.7rem',
                         transform: 'translateY(-50%)',
                     }}
                     onClick={onClick || (() => navigate(-1))} 
                 />
                 {!hideTitle && <HeaderContainer>{header}</HeaderContainer>}
-            </HeaderWrapper>
+            </HeaderWrapperBig>
         );
     }
   }

--- a/sws/src/main/page/Main.jsx
+++ b/sws/src/main/page/Main.jsx
@@ -133,11 +133,10 @@ const NoLectureMessage = styled.div`
   padding: 2rem 0;
 `;
 
-
-const MyLectureItem = ({ lecture }) => {
+const MyLectureItem = ({ lecture, onClick }) => { 
   console.log("MyLectureItem 렌더링 시도. lecture 객체:", lecture);
   return (
-    <MyLectureItemWrapper> 
+    <MyLectureItemWrapper onClick={onClick}>  
       <LectureName>{lecture.name || lecture.courseTitle || '강의 제목 없음'}</LectureName> 
     </MyLectureItemWrapper>
   );
@@ -150,6 +149,7 @@ const MyLectureItemWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   box-sizing: border-box;
+  cursor: pointer;
   flex-shrink: 0;
 `;
 //강의 이름텍스트 스타일
@@ -295,11 +295,11 @@ const IconCoffeeChat = styled.div`
   justify-content: flex-end;
   align-items: flex-end;
 `;
-const MainSNR = ({ senior }) => {
+const MainSNR = ({ senior, onClick }) => { 
   return (
-    <StyledMainSNR>
+    <StyledMainSNR onClick={onClick}> 
       <MainSNRProfile>
-        <ProfileImageSmall src={senior.profileImage || ProfileDefaultImage} alt="프로필 이미지"/>
+        <ProfileImageSmall src={senior.profileImage || DEFAULT_PROFILE_IMAGE_PATH} alt="프로필 이미지"/>
         <MainSNRInfo>
           <MainSNRFrameTop>
             <SNRNickname>{senior.name}</SNRNickname> 
@@ -324,7 +324,6 @@ const MainSNR = ({ senior }) => {
   );
 };
 
-
 // MainSNR의 스타일을 정의하는 styled-component 
 const StyledMainSNR = styled.div`
   width: 100%; 
@@ -335,6 +334,7 @@ const StyledMainSNR = styled.div`
   align-items: center;
   gap: 5.5rem;
   align-self: stretch;
+  cursor: pointer;
 `;
 // (main_snr_profile)
 const MainSNRProfile = styled.div`
@@ -482,9 +482,9 @@ const MoreEwhainButton = styled.button`
   font-weight: 600;
   line-height: normal;
 `;
-const MainEwhain = ({ ewhain }) => {
+const MainEwhain = ({ ewhain, onClick }) => {
   return (
-    <StyledMainEwhain>
+    <StyledMainEwhain onClick={onClick}> 
       <MainEwhainProfile>
         <EwhainProfileImage src={ewhain.profileImage || ProfileDefaultImage} alt="프로필 이미지"/>
         <MainEwhainInfo>
@@ -536,7 +536,7 @@ const StyledMainEwhain = styled.div`
   align-items: center;
   gap: 2.5rem;
   align-self: stretch;
-
+   cursor: pointer;
 `;
 
 const MainEwhainProfile = styled.div`
@@ -650,6 +650,14 @@ export default function Main() {
   const handleMoreEwhainClick = () => {
     navigate('/ewhainlist'); 
   };
+  const handleMyLectureItemClick = useCallback((courseId) => {
+    navigate(`/lectures/detail/${courseId}`);
+  }, [navigate]);
+
+  const handleSeniorClick = useCallback((memberId) => {
+    navigate(`/ewhainlist/${memberId}`); 
+  }, [navigate]);
+
   const [recommendedLectures, setRecommendedLectures] = useState([]);
   const [recommendedLecturesLoading, setRecommendedLecturesLoading] = useState(false);
   const [recommendedLecturesError, setRecommendedLecturesError] = useState(null);  
@@ -920,7 +928,11 @@ useEffect(() => {
         <LectureGrid>
           {userProfile.ongoingLectures.map((lecture, index) => (
             <React.Fragment key={lecture.courseId}>
-              <MyLectureItem lecture={lecture} /> 
+             <MyLectureItem
+            onClick={() => handleMyLectureItemClick(lecture.courseId)}
+            key={lecture.courseId}
+            lecture={lecture}
+          />
               {index < userProfile.ongoingLectures.length - 1 && <Divider />} 
             </React.Fragment>
           ))}
@@ -981,17 +993,16 @@ useEffect(() => {
         {!seniorListLoading && !seniorListError && seniorList.length > 0 ? (
             seniorList.map((senior, index) => (
               <React.Fragment key={senior.memberId}>
-                {console.log("🔴 [Main.jsx -> MainSNR] senior 객체:", senior)}
-    {console.log("🔴 [Main.jsx -> MainSNR] senior.profileImage 값:", senior.profileImage)}
 
-                <MainSNR senior={{
-                    id: senior.memberId,
-                    name: senior.nickName, 
-                    major: senior.department, 
-                    talents: senior.talentTags || [], 
-                    location: senior.location,
-                    profileImage: senior.profileImage || senior.profileImg || DEFAULT_PROFILE_IMAGE_PATH,
-                    coffeeChat: senior.coffeeChat,
+                <MainSNR onClick={() => handleSeniorClick(senior.memberId)}
+              senior={{
+                  id: senior.memberId,
+                  name: senior.nickName, 
+                  major: senior.department, 
+                  talents: senior.talentTags || [], 
+                  location: senior.location,
+                  profileImage: senior.profileImage || senior.profileImg || DEFAULT_PROFILE_IMAGE_PATH,
+                  coffeeChat: senior.coffeeChat,
                 }} />
                 {index < seniorList.length - 1 && <Divider />}
               </React.Fragment>
@@ -1016,7 +1027,9 @@ useEffect(() => {
         ) : ( 
           ewhainList.map((ewhain, index) => (
             <React.Fragment key={ewhain.memberId}> 
-              <MainEwhain ewhain={{
+              <MainEwhain 
+              onClick={() => handleSeniorClick(ewhain.memberId)}
+              ewhain={{
                   id: ewhain.memberId,
                   name: ewhain.nickName,
                   major: ewhain.department,

--- a/sws/src/main/page/lecture/LectureDetailPage.jsx
+++ b/sws/src/main/page/lecture/LectureDetailPage.jsx
@@ -463,6 +463,7 @@ export default function LectureDetailPage() {
     };
     fetchLectureDetail(); 
   }, [lectureId]);
+  
   const handleBackClick = () => {
     navigate(-1);
   };


### PR DESCRIPTION
## 📌 Related Issue

#84 

<br/>

## 🚀 Description

1.**메인/페이지 프로필 사진 표시 **

2.  **Header 컴포넌트 (`src/common/components/Header.jsx`) 개선**
    *   `Layout.jsx`의 `<HeaderComponent>` 사용 방식에 맞춰 `header` prop을 처리하도록 로직을 재정비했습니다.
  
3.  **라우팅 및 내비게이션 기능 확장**
    *   **내 강의 목록 클릭 이동**: 메인 페이지 `MyLectureItem` 클릭 시 해당 강의의 `LectureDetailPage`로 이동하도록 연결했습니다.
    *   **학과 선배 목록 클릭 이동**: 메인 페이지 `MainSNR` 클릭 시 해당 선배의 `EwhainDetailPage`로 이동하도록 연결했습니다.
    *   `useNavigate` 훅 사용 위치를 컴포넌트 역할에 맞게(`Main.jsx` 등 상위 컴포넌트에서) 조정했습니다.

4.  **전체 검색 기능 (`GlobalSearchPage`) 연동 시작**
    *   `GET /search` API를 연동하여 검색 결과를 가져오고 화면에 표시하기 위한 기반을 마련했습니다.
    *   `Axios` 인스턴스 (`src/api/api.js`)를 생성하여 API 통신의 일관성과 효율성을 높였습니다.
    *   `searchAll` API 호출 로직 (`src/api/search.js`)과 `GlobalSearchPage.jsx`의 연동을 구현했습니다.
   

5.  **알림 기능 연동 시작**
    *   `GET /notification` API 호출 (`src/api/notification.js`) 및 `useAlarm()` 훅(`src/hooks/useAlarm.js`)을 연동하여 알림 목록 및 읽지 않은 알림 개수를 받아오는 로직을 구현했습니다.
    *   API 응답(`notifications`, `unreadCount` 필드)에 맞춰 `useAlarm()` 훅의 상태 업데이트 로직을 수정했습니다.

<br/>

## 📸 Screenshot


<br/>

## 📢 Notes

**로그인 `500 Internal Server Error` (Critical Blocker)**
    *   **현상**: 카카오/구글 로그인 시 `500 Internal Server Error`가 발생하여 `accessToken`을 받지 못하고 있습니다.
    *   **영향**: 이 때문에 `GET /search`, `GET /notification` 등 `Authorization` 헤더가 필요한 **모든 API가 `401 Unauthorized` 에러**를 발생시키고 있습니다.